### PR TITLE
fix requirements for sphinx build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
 jupyter-book==0.12.3
 pyppeteer
 pybtex-apa-style>=1.3
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+lxml_html_clean
+


### PR DESCRIPTION
Taking suggestion from https://stackoverflow.com/questions/77848565/sphinxcontrib-applehelp-breaking-sphinx-builds-with-sphinx-version-less-than-5-0

This is an issue because utterances still aren't fixed, so we're stuck on an old version of sphinx https://github.com/executablebooks/jupyter-book/issues/1762#issuecomment-1532896199

Really this whole jupyterbook build should be reviewed and simplified